### PR TITLE
DEV-1324 add test for tableau mh db user

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,8 @@ hvac = "*"
 robotframework-ftplibrary = "*"
 lxml = "*"
 robotframework-requests = "*"
+robotframework-databaselibrary = ">=1.2.4"
+psycopg2-binary = "*"
 
 [requires]
 python_version = "3"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Some links about:
 ## Prerequisites
 
 - Python >=3.6
-- [Geckodriver](https://github.com/mozilla/geckodriver/releases/latest) (Download and untar to `/usr/local/bin`)
-- [pipenv](https://pipenv-fork.readthedocs.io/en/latest/)
+- [Geckodriver](run `brew install geckodriver` on Mac, or https://github.com/mozilla/geckodriver/releases/latest)
+- [pipenv](run `brew install pipenv` on Mac, or https://pipenv-fork.readthedocs.io/en/latest/)
 
 ## Installation
 

--- a/tests/mediahaven/database/db-resource.robot
+++ b/tests/mediahaven/database/db-resource.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Documentation     A resource file with higher-order keywords for DB Monitoring.
+Library           DatabaseLibrary
+Library           Vault/Vault.py  %{VAULT_ADDR}  %{GITHUB_TOKEN}  False
+
+*** Variables ***
+${HOST}            ${mediahaven.database.url}
+${DB}              mediahaven_data
+${PORT}            1433
+${DBMODULE}        psycopg2
+
+*** Keywords ***
+Get username from vault
+    [Arguments]     ${path}
+    &{secret_key}=  GetSecret   ${path}
+    [return]        ${secret_key.username}
+
+Get passwd from vault
+    [Arguments]     ${path}
+    &{secret_key}=  GetSecret   ${path}
+    [return]        ${secret_key.passwd}
+
+Connect To Mediahaven DB
+    [Arguments]     ${username}     ${passwd}
+    Connect To Database     ${DBMODULE}     ${DB} 	${username} 	${passwd} 	${HOST} 	${PORT}
+
+Disconnect From Mediahaven DB
+    Disconnect From Database
+
+Sips View Should Be Readable
+    Check If Exists In Database     select viewname from pg_catalog.pg_views where viewname IN ('sips');

--- a/tests/mediahaven/database/db-tableau.robot
+++ b/tests/mediahaven/database/db-tableau.robot
@@ -7,8 +7,8 @@ Resource          db-resource.robot
 *** Test Cases ***
 Tableau Login to MH postgresql db
     [Tags]    tableau  login  mediahaven  prd  qas  int
-    ${username}=    Get username from vault   mediahaven_tableau
-    ${passwd}=      Get passwd from vault     mediahaven_tableau
+    ${username}=    Get username from vault   mediahaven.tableau
+    ${passwd}=      Get passwd from vault     mediahaven.tableau
     Connect To Mediahaven DB    ${username}     ${passwd}
     Sips View Should Be Readable
     [Teardown]    Disconnect From Mediahaven DB

--- a/tests/mediahaven/database/db-tableau.robot
+++ b/tests/mediahaven/database/db-tableau.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Documentation     A test suite for the database access
+...
+...               A single valid login test for the MediaHaven tableau user in the database
+Resource          db-resource.robot
+
+*** Test Cases ***
+Tableau Login to MH postgresql db
+    [Tags]    tableau  login  mediahaven  prd  qas  int
+    ${username}=    Get username from vault   mediahaven_tableau
+    ${passwd}=      Get passwd from vault     mediahaven_tableau
+    Connect To Mediahaven DB    ${username}     ${passwd}
+    Sips View Should Be Readable
+    [Teardown]    Disconnect From Mediahaven DB


### PR DESCRIPTION
Adds a check for whether DB user 'tableau' can login and see the sips view in the mediahaven DB