### PR TITLE
DEV-1742 Make MH auth configurable per environment

### DIFF
--- a/env.yaml.example
+++ b/env.yaml.example
@@ -1,5 +1,6 @@
 environment:
     name: ~
+    short_name: ~
 mediahaven:
     monitoring:
         url: ~

--- a/tests/mediahaven/http.resource
+++ b/tests/mediahaven/http.resource
@@ -34,7 +34,7 @@ Get auth header for
 
 Create RequestsSession with headers
     [Arguments]         ${alias}        ${url}
-    ${headers}=         Get auth header for     mediahaven
+    ${headers}=         Get auth header for     mediahaven.admin_user.${environment.short_name}
     Set To Dictionary   ${headers}      Accept=application/xml
     Create Session      ${alias}        ${url}   ${headers}
     

--- a/tests/mediahaven/monitoring/monitoring.robot
+++ b/tests/mediahaven/monitoring/monitoring.robot
@@ -9,8 +9,8 @@ Resource          monitoring-resource.robot
 Valid Login to MH monitoring interface
     [Tags]    web-test  login  mediahaven  prd  qas  int
     Open Browser To Login Page
-    ${username}=    Get username from vault   mediahaven
-    ${passwd}=      Get passwd from vault     mediahaven
+    ${username}=    Get username from vault   mediahaven.admin_user.${environment.short_name}
+    ${passwd}=      Get passwd from vault     mediahaven.admin_user.${environment.short_name}
     Input Username    ${username}
     Input Password    ${passwd}
     Submit Credentials

--- a/tests/mediahaven/rest/rest.robot
+++ b/tests/mediahaven/rest/rest.robot
@@ -4,7 +4,7 @@ Documentation    Test #022\n
 ...              See: https://meemoo.atlassian.net/wiki/spaces/SI/pages/1105887278/Test+022+-+Testing+van+de+REST+API
 Library       REST    https://${mediahaven.rest.url}/mediahaven-rest-api/resources
 Resource      ../http.resource
-Test setup    Set auth header for     mediahaven
+Test setup    Set auth header for     mediahaven.admin_user.${environment.short_name}
 
 *** Test Cases ***
 Test current user
@@ -12,9 +12,6 @@ Test current user
   Get         /users/current
   Object      response body
   Integer     response status   200
-  String      $.firstName       VIAA
-  String      $.id              ff100f7a-efd0-44e3-8816-0905572421da
-  String      $.login           viaa@viaa
   Expect Response   ${CURDIR}/schemas/users_current.json
   Clear Expectations
 


### PR DESCRIPTION
For every MediaHaven environment, it fetches the same credentials from
the Vault. However, every environment has its own credentials. Make it
configurable, so that the specific credentials for the enviroment are
used.

Instead of fixing some assertions in the "Test current user" test, the
assertions are removed as they are not really useful.