### PR TITLE
DEV-1745 Fix monitoring tests for ldap users

### DIFF
--- a/tests/mediahaven/monitoring/monitoring-generic-users.robot
+++ b/tests/mediahaven/monitoring/monitoring-generic-users.robot
@@ -17,8 +17,7 @@ Test generic LDAP users
     Input Username   ${user["username"]}
     Input Password   ${user["passwd"]}
     Submit Credentials
-    Index Page Should Be Open
-    Logout
+    Index Page Should Not Be Open
   END
   [Teardown]    Close Browser
 

--- a/tests/mediahaven/monitoring/monitoring-resource.robot
+++ b/tests/mediahaven/monitoring/monitoring-resource.robot
@@ -37,9 +37,14 @@ Logout
     Click Link      id:logout
 
 Index Page Should Be Open
-    Wait Until Location Contains    index.php    
+    Wait Until Location Contains    index.php
     Location Should Contain         index.php
     Page Should Contain Element     id:logout
+
+Index Page Should Not Be Open
+    Wait Until Element Is Visible   id:errors
+    Element Should Contain          id:errors   has no permission to view backend monitoring
+    Location Should Contain         login.php
 
 Index Page Should Have All Tabs
     Page Should Contain Element     link:Ingest


### PR DESCRIPTION
Generic ldap users should not be allowed to log in to the monitoring tool.