### PR TITLE
DEV-1750 Add REST login test for ldap users

### DIFF
--- a/tests/mediahaven/rest/rest-users.robot
+++ b/tests/mediahaven/rest/rest-users.robot
@@ -8,6 +8,21 @@ Resource        ../http.resource
 
 
 *** Test Cases ***
+Test generic LDAP users
+  [Tags]      rest  mediahaven  login   prd  qas  int
+  &{json_string}=    GetSecret     mediahaven.generic_ldap_users.${environment.short_name}
+  ${generic_users}=  Set Variable  ${json_string.json}
+  FOR    ${user}     IN      @{generic_users}
+    Log To Console    Testing: ${user["username"]}
+    Set auth header   ${user["username"]}  ${user["passwd"]}
+    Get         /users/current
+    Object      response body
+    Integer     response status   200
+    String      $.login           ${user["username"]}
+    Expect Response   ${CURDIR}/schemas/users_current.json
+    Clear Expectations
+  END
+
 Test generic local users
   [Tags]      rest  mediahaven  login   prd  qas  int
   &{json_string}=    GetSecret     mediahaven.generic_local_users.${environment.short_name}
@@ -22,4 +37,3 @@ Test generic local users
     Expect Response   ${CURDIR}/schemas/users_current.json
     Clear Expectations
   END
-  


### PR DESCRIPTION
Test if the generic ldap users can log in to MediaHaven via the REST API
and thus be able to communicate with MediaHaven via the REST API.