### PR TITLE
DEV-1978 Fix monitoring tests

### DIFF
--- a/tests/mediahaven/monitoring/monitoring-generic-users.robot
+++ b/tests/mediahaven/monitoring/monitoring-generic-users.robot
@@ -14,9 +14,10 @@ Test generic LDAP users
   FOR    ${user}     IN      @{generic_users}
     Log To Console    Testing: ${user["username"]}
     Open Browser To Login Page
-    Input Username   ${user["username"]}
-    Input Password   ${user["passwd"]}
-    Submit Credentials
+    Open IDP page
+    Input Username IDP meemoo  ${user["username"]}
+    Input Password IDP meemoo  ${user["passwd"]}
+    Submit Credentials IDP meemoo
     Index Page Should Not Be Open
   END
   [Teardown]    Close Browser
@@ -28,9 +29,9 @@ Test generic local users
   FOR    ${user}     IN      @{generic_users}
     Log To Console    Testing: ${user["username"]}
     Open Browser To Login Page
-    Input Username   ${user["username"]}
-    Input Password   ${user["passwd"]}
-    Submit Credentials
+    Input Username MediaHaven   ${user["username"]}
+    Input Password MediaHaven   ${user["passwd"]}
+    Submit Credentials MediaHaven
     Index Page Should Be Open
     Logout
   END

--- a/tests/mediahaven/monitoring/monitoring-resource.robot
+++ b/tests/mediahaven/monitoring/monitoring-resource.robot
@@ -16,22 +16,43 @@ Open Browser To Login Page
     Login Page Should Be Open
 
 Login Page Should Be Open
-    Page Should Contain Element     id:login
+    Wait Until Page Contains    Login
 
 Go To Login Page
     Go To    ${LOGIN_URL}
     Login Page Should Be Open
 
-Input Username
+Open IDP page
+    Click Button    xpath://button[@name="serviceLogin" and @value="viaa"]
+    Wait Until Page Contains Element    id:loginform
+
+Input Username MediaHaven
     [Arguments]    ${username}
-    Input Text     id:inputEmail3    ${username}
+    Input Text     id:input-field-username   ${username}
 
-Input Password
+Input Password MediaHaven
     [Arguments]    ${password}
-    Input Text     id:inputPassword3    ${password}
+    Input Text     id:input-field-password    ${password}
 
-Submit Credentials
-    Submit Form
+Submit Credentials MediaHaven
+    Click Button   xpath://button[@name="serviceLogin" and @value="mediahaven"]
+    Allow access if needed
+
+Input Username IDP meemoo
+    [Arguments]    ${username}
+    Input Text     id:inputUsername   ${username}
+
+Input Password IDP meemoo
+    [Arguments]    ${password}
+    Input Text     id:inputPassword    ${password}
+
+Submit Credentials IDP meemoo
+    Click Button     id:wp-submit
+
+Allow access if needed
+    Sleep   1s  Wait to allow the access dialog to show if needed
+    ${count}=   Get Element Count    xpath://button[@name="giveperms" and @value="true"]
+    Run Keyword If      $count == 1     Click Button    xpath://button[@name="giveperms" and @value="true"]
 
 Logout
     Click Link      id:logout
@@ -42,9 +63,8 @@ Index Page Should Be Open
     Page Should Contain Element     id:logout
 
 Index Page Should Not Be Open
-    Wait Until Element Is Visible   id:errors
-    Element Should Contain          id:errors   has no permission to view backend monitoring
-    Location Should Contain         login.php
+    Wait Until Page Contains        has no permission to view backend monitoring
+    Location Should Contain         error.php
 
 Index Page Should Have All Tabs
     Page Should Contain Element     link:Ingest

--- a/tests/mediahaven/monitoring/monitoring.robot
+++ b/tests/mediahaven/monitoring/monitoring.robot
@@ -11,9 +11,9 @@ Valid Login to MH monitoring interface
     Open Browser To Login Page
     ${username}=    Get username from vault   mediahaven.admin_user.${environment.short_name}
     ${passwd}=      Get passwd from vault     mediahaven.admin_user.${environment.short_name}
-    Input Username    ${username}
-    Input Password    ${passwd}
-    Submit Credentials
+    Input Username MediaHaven   ${username}
+    Input Password MediaHaven   ${passwd}
+    Submit Credentials MediaHaven
     Index Page Should Be Open
     Index Page Should Have All Tabs
     [Teardown]    Close Browser


### PR DESCRIPTION
The login page has changed in MediaHaven 22.1:
 - Login form contains different (name of) elements.
 - Monitoring tool is now an OAuth2 client meaning that you need to allow
   that client to grant access to the account you're logging in with.
   Although this is a one time event, in the context of automated testing,
   it needs to be implemented.
 - The generic LDAP users need to log in via IDP by clicking the "viaa"
   button first. Do note that they do not have the rights to actually log
   into the monitoring tool.